### PR TITLE
Sets Laravel Nova version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
   ],
   "license": "MIT",
   "require": {
-    "php": "^7.3|^8.0"
+    "php": "^7.3|^8.0",
+    "laravel/nova": "^4.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
composer.json does not specify the minimum Laravel Nova version in this package. This PR adds a min. version of 4.0, preventing package installation on unsupported Nova instances.