### PR TITLE
Filter & sort log files

### DIFF
--- a/src/Http/Controllers/Pages/LogViewerController.php
+++ b/src/Http/Controllers/Pages/LogViewerController.php
@@ -26,6 +26,7 @@ class LogViewerController extends Controller
                     'value' => $log->getRelativePathname(),
                 ];
             })
+            ->sortByDesc('label')
             ->values();
 
         return Inertia::render('NovaLogViewer', [

--- a/src/Http/Controllers/Pages/LogViewerController.php
+++ b/src/Http/Controllers/Pages/LogViewerController.php
@@ -18,15 +18,18 @@ class LogViewerController extends Controller
      */
     public function __invoke()
     {
-        $logs = FileFacade::allFiles(storage_path('logs'));
-
-        return Inertia::render('NovaLogViewer', [
-            'logs' => collect($logs)->map(function (SplFileInfo $log) {
+        $logs = collect(FileFacade::allFiles(storage_path('logs')))
+            ->filter(fn (SplFileInfo $log) => $log->getExtension() === 'log')
+            ->map(function (SplFileInfo $log) {
                 return [
                     'label' => $log->getRelativePathname(),
                     'value' => $log->getRelativePathname(),
                 ];
-            }),
+            })
+            ->values();
+
+        return Inertia::render('NovaLogViewer', [
+            'logs' => $logs,
         ]);
     }
 


### PR DESCRIPTION
Hi team!

This PR applies some basic filtering to only show files with a `.log` extension in the dropdown menu, this ensures the Tool doesn't show a Server Error due to other file types being (auto-)selected, eg: `.gz` which are automatically created for older log files (see screenshot).

<img width="300" src="https://user-images.githubusercontent.com/5065331/195990657-4ca9a413-4ee8-43e0-900f-d914455d83b9.jpg">

Additionally, the files are now sorted descending by name which ensures the latest file is auto-selected when opening the Nova Log Viewer tool (when using `daily` logging channel).

Please let me know if there's any questions/issues. Thanks!