### PR TITLE
Fix: redirect unauthenticated users instead of returning 403

### DIFF
--- a/src/Http/Middleware/Authorize.php
+++ b/src/Http/Middleware/Authorize.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Nova\LogViewer\Http\Middleware;
 
-use Laravel\Nova\Exceptions\AuthenticationException as NovaAuthenticationException;
 use Laravel\Nova\LogViewer\LogViewer;
 use Laravel\Nova\Nova;
 
@@ -17,10 +16,6 @@ class Authorize
      */
     public function handle($request, $next)
     {
-        if (! $request->user()) {
-            throw new NovaAuthenticationException('Unauthenticated.');
-        }
-        
         $tool = collect(Nova::registeredTools())->first([$this, 'matchesTool']);
 
         return optional($tool)->authorize($request) ? $next($request) : abort(403);

--- a/src/Http/Middleware/Authorize.php
+++ b/src/Http/Middleware/Authorize.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Nova\LogViewer\Http\Middleware;
 
+use Laravel\Nova\Exceptions\AuthenticationException as NovaAuthenticationException;
 use Laravel\Nova\LogViewer\LogViewer;
 use Laravel\Nova\Nova;
 
@@ -16,6 +17,10 @@ class Authorize
      */
     public function handle($request, $next)
     {
+        if (! $request->user()) {
+            throw new NovaAuthenticationException('Unauthenticated.');
+        }
+        
         $tool = collect(Nova::registeredTools())->first([$this, 'matchesTool']);
 
         return optional($tool)->authorize($request) ? $next($request) : abort(403);

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -46,10 +46,10 @@ class ToolServiceProvider extends ServiceProvider
             return;
         }
 
-        Nova::router(['nova', Authorize::class], 'logs')
+        Nova::router(['nova', Authenticate::class, Authorize::class], 'logs')
             ->group(__DIR__.'/../routes/inertia.php');
 
-        Route::middleware(['nova', Authorize::class])
+        Route::middleware(['nova', Authenticate::class, Authorize::class])
             ->prefix('nova-vendor/logs')
             ->group(__DIR__.'/../routes/api.php');
     }


### PR DESCRIPTION
**Problem**
When an unauthenticated user visits `/nova/logs`, the `Authorize` middleware evaluates the tool's `canSee` callback with `$request->user()` being null. This causes the callback to return `false`, after which the middleware calls `abort(403)`.

This is incorrect for two reasons:

1. UX: Unauthenticated users should be redirected to the login page, not shown a 403 error.
2. Security: A 403 response on `/nova/logs` reveals that the application is running Laravel Nova with the Log Viewer tool installed. A redirect to login leaks no such information.

**Root cause**
`Authenticate::class` was missing from the middleware stack in `ToolServiceProvider`. Comparing with other Nova tools (including Nova's own first-party tools) shows that Authenticate::class should always be included between `nova` and `Authorize::clas`s:

```
// Before
Nova::router(['nova', Authorize::class], 'logs')
Route::middleware(['nova', Authorize::class])

// Other Nova tools do this correctly:
Nova::router(['nova', Authenticate::class, Authorize::class], 'docs')
Route::middleware(['nova', Authenticate::class, Authorize::class])
```

Without `Authenticate::class`, unauthenticated requests pass straight through to `Authorize::class`, which only checks tool authorization and calls `abort(403`) — never giving Nova's authentication flow a chance to redirect to the login page.

**Fix**
Add `Authenticate::class` to both middleware stacks, consistent with how other Nova tools handle this:

```
Nova::router(['nova', Authenticate::class, Authorize::class], 'logs')
Route::middleware(['nova', Authenticate::class, Authorize::class])
```

**Before**
Unauthenticated visit to `/nova/logs` → `403 Forbidden` (leaks that Nova + Log Viewer is installed)

**After**
Unauthenticated visit to `/nova/logs `→ redirect to `loginPath` (e.g. /login)