### PR TITLE
Fix: add missing Authenticate middleware use statement

### DIFF
--- a/src/Http/Middleware/Authorize.php
+++ b/src/Http/Middleware/Authorize.php
@@ -2,7 +2,6 @@
 
 namespace Laravel\Nova\LogViewer\Http\Middleware;
 
-use Laravel\Nova\Exceptions\AuthenticationException as NovaAuthenticationException;
 use Laravel\Nova\LogViewer\LogViewer;
 use Laravel\Nova\Nova;
 
@@ -17,10 +16,6 @@ class Authorize
      */
     public function handle($request, $next)
     {
-        if (! $request->user()) {
-            throw new NovaAuthenticationException('Unauthenticated.');
-        }
-        
         $tool = collect(Nova::registeredTools())->first([$this, 'matchesTool']);
 
         return optional($tool)->authorize($request) ? $next($request) : abort(403);

--- a/src/Http/Middleware/Authorize.php
+++ b/src/Http/Middleware/Authorize.php
@@ -2,6 +2,7 @@
 
 namespace Laravel\Nova\LogViewer\Http\Middleware;
 
+use Laravel\Nova\Exceptions\AuthenticationException as NovaAuthenticationException;
 use Laravel\Nova\LogViewer\LogViewer;
 use Laravel\Nova\Nova;
 
@@ -16,6 +17,10 @@ class Authorize
      */
     public function handle($request, $next)
     {
+        if (! $request->user()) {
+            throw new NovaAuthenticationException('Unauthenticated.');
+        }
+        
         $tool = collect(Nova::registeredTools())->first([$this, 'matchesTool']);
 
         return optional($tool)->authorize($request) ? $next($request) : abort(403);

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -5,6 +5,7 @@ namespace Laravel\Nova\LogViewer;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Nova\Events\ServingNova;
+use Laravel\Nova\Http\Middleware\Authenticate;
 use Laravel\Nova\LogViewer\Http\Middleware\Authorize;
 use Laravel\Nova\Nova;
 

--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -46,10 +46,10 @@ class ToolServiceProvider extends ServiceProvider
             return;
         }
 
-        Nova::router(['nova', Authorize::class], 'logs')
+        Nova::router(['nova', Authenticate::class, Authorize::class], 'logs')
             ->group(__DIR__.'/../routes/inertia.php');
 
-        Route::middleware(['nova', Authorize::class])
+        Route::middleware(['nova', Authenticate::class, Authorize::class])
             ->prefix('nova-vendor/logs')
             ->group(__DIR__.'/../routes/api.php');
     }


### PR DESCRIPTION
Follow-up to #22. The Authenticate middleware was added to the stack but the corresponding use statement was not included in the commit